### PR TITLE
feat: add support for Ollama and OpenAI-compatible API endpoints

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -24,10 +24,22 @@ pip install -e .
 
 ## 2. Get API Keys
 
+**Option A: OpenAI (default)**
+
 1. **OpenAI API Key**: [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
 2. **GitHub Token**: [github.com/settings/tokens](https://github.com/settings/tokens) (check `repo` scope)
 
+**Option B: Local Models (free!)**
+
+1. Install [Ollama](https://ollama.ai/) and pull a model:
+   ```bash
+   ollama pull llama3.2
+   ```
+2. **GitHub Token**: [github.com/settings/tokens](https://github.com/settings/tokens) (check `repo` scope)
+
 ## 3. Configure
+
+**Using OpenAI:**
 
 ```bash
 # Set your OpenAI API key
@@ -35,6 +47,41 @@ aigit config set openai_api_key sk-your-key-here
 
 # Set your GitHub token
 aigit config set github_token ghp_your-token-here
+```
+
+**Using Ollama (local):**
+
+```bash
+# Set provider to Ollama
+aigit config set provider ollama
+
+# Set model (no API key needed!)
+aigit config set model llama3.2
+
+# Set your GitHub token
+aigit config set github_token ghp_your-token-here
+```
+
+**Using other providers:**
+
+```bash
+# Llama.cpp
+aigit config set provider llamacpp
+aigit config set model local-model
+
+# vLLM
+aigit config set provider vllm
+aigit config set model meta-llama/Meta-Llama-3-8B
+
+# OpenRouter
+aigit config set provider openrouter
+aigit config set openai_api_key sk-or-v1-...
+aigit config set model anthropic/claude-3.5-sonnet
+
+# Custom endpoint
+aigit config set provider custom
+aigit config set base_url http://your-endpoint/v1
+aigit config set model your-model
 ```
 
 ## 4. Try it out
@@ -112,4 +159,39 @@ Or export as environment variable:
 ```bash
 export OPENAI_API_KEY=sk-your-key-here
 ```
+
+Or use a local provider like Ollama (no API key needed):
+```bash
+aigit config set provider ollama
+aigit config set model llama3.2
+```
+
+### Connection errors with Ollama
+
+Make sure Ollama is running:
+```bash
+ollama serve
+```
+
+And verify the model is pulled:
+```bash
+ollama pull llama3.2
+```
+
+## Model Recommendations
+
+**For OpenAI:**
+- `gpt-4o-mini` - Fast and cheap (default)
+- `gpt-4o` - Better quality, more expensive
+- `gpt-4-turbo` - Good balance
+
+**For Ollama:**
+- `llama3.2` - Fast, good for commits
+- `codellama` - Optimized for code
+- `mistral` - Good alternative
+
+**For OpenRouter:**
+- `anthropic/claude-3.5-sonnet` - Excellent quality
+- `meta-llama/llama-3.1-70b-instruct` - Open source, powerful
+- `google/gemini-pro` - Fast and capable
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ pip install -e .
 
 ### Configure aigit
 
+**Using OpenAI (default):**
+
 ```bash
 # Set your API keys
 aigit config set openai_api_key sk-...
@@ -105,6 +107,57 @@ Or use environment variables:
 export OPENAI_API_KEY=sk-...
 export GITHUB_TOKEN=ghp_...
 ```
+
+### Alternative AI Providers
+
+aigit supports multiple AI providers through OpenAI-compatible APIs:
+
+**Ollama (local models):**
+
+```bash
+aigit config set provider ollama
+aigit config set model llama3.2    # or mistral, codellama, etc.
+# No API key needed!
+```
+
+**Llama.cpp server:**
+
+```bash
+aigit config set provider llamacpp
+aigit config set model local-model
+```
+
+**vLLM:**
+
+```bash
+aigit config set provider vllm
+aigit config set model meta-llama/Meta-Llama-3-8B
+```
+
+**OpenRouter:**
+
+```bash
+aigit config set provider openrouter
+aigit config set openai_api_key sk-or-v1-...
+aigit config set model anthropic/claude-3.5-sonnet
+```
+
+**Custom endpoint:**
+
+```bash
+aigit config set provider custom
+aigit config set base_url http://your-api-endpoint/v1
+aigit config set openai_api_key your-key-if-needed
+aigit config set model your-model-name
+```
+
+**Provider default URLs:**
+- Ollama: `http://localhost:11434/v1`
+- Llama.cpp: `http://localhost:8080/v1`
+- vLLM: `http://localhost:8000/v1`
+- OpenRouter: `https://openrouter.ai/api/v1`
+
+> **Note:** For Ollama, Llama.cpp, and vLLM, no API key is required. Make sure your local server is running before using aigit.
 
 ## Usage
 
@@ -197,7 +250,10 @@ Configuration is stored in `~/.config/aigit/config.toml`
 Available options:
 - `openai_api_key`: OpenAI API key
 - `github_token`: GitHub personal access token
-- `model`: OpenAI model to use (default: `gpt-4o-mini`)
+- `model`: Model to use (default: `gpt-4o-mini`)
+- `provider`: AI provider (default: `openai`)
+  - Options: `openai`, `ollama`, `llamacpp`, `vllm`, `openrouter`, `custom`
+- `base_url`: Custom API base URL (overrides provider default)
 - `conventional_commits`: Use conventional commits format (default: `true`)
 - `auto_stage`: Auto-stage all changes (default: `false`)
 - `interactive`: Show interactive prompts (default: `true`)
@@ -206,7 +262,13 @@ Available options:
 
 - Python 3.10+
 - Git
-- [OpenAI API key](https://platform.openai.com/api-keys)
+- One of the following AI providers:
+  - [OpenAI API key](https://platform.openai.com/api-keys) (default)
+  - [Ollama](https://ollama.ai/) running locally
+  - [Llama.cpp](https://github.com/ggerganov/llama.cpp) server
+  - [vLLM](https://github.com/vllm-project/vllm) server
+  - [OpenRouter](https://openrouter.ai/) account
+  - Any OpenAI-compatible API endpoint
 - [GitHub personal access token](https://github.com/settings/tokens) (for PR features)
   - Needs `repo` scope for creating PRs
 

--- a/aigit/commands/config.py
+++ b/aigit/commands/config.py
@@ -35,7 +35,7 @@ def config_command(
         try:
             cfg.set_config(key, value)
             console.print(f"[green]✓[/green] Set {key} = {value}")
-            
+
             # Display helpful messages for provider configuration
             if key == "provider":
                 provider_info = cfg.PROVIDER_DEFAULTS.get(value, {})
@@ -45,10 +45,10 @@ def config_command(
                     console.print("[dim]API key not required for this provider[/dim]")
                 else:
                     console.print("[yellow]⚠[/yellow]  Don't forget to set your API key: aigit config set openai_api_key <key>")
-                    
+
             if key == "base_url" and value:
                 console.print("[dim]Custom base URL will override provider default[/dim]")
-                
+
         except Exception as e:
             console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(1)

--- a/aigit/commands/config.py
+++ b/aigit/commands/config.py
@@ -8,6 +8,8 @@ from aigit import config as cfg
 
 console = Console()
 
+SUPPORTED_PROVIDERS = ["openai", "ollama", "llamacpp", "vllm", "openrouter", "custom"]
+
 
 def config_command(
     action: str = typer.Argument(..., help="Action: set, get, or list"),
@@ -23,9 +25,30 @@ def config_command(
             console.print("[red]Usage:[/red] aigit config set <key> <value>")
             raise typer.Exit(1)
 
+        # Validate provider
+        if key == "provider":
+            if value not in SUPPORTED_PROVIDERS:
+                console.print(f"[red]Error:[/red] Invalid provider '{value}'")
+                console.print(f"[yellow]Supported providers:[/yellow] {', '.join(SUPPORTED_PROVIDERS)}")
+                raise typer.Exit(1)
+
         try:
             cfg.set_config(key, value)
             console.print(f"[green]✓[/green] Set {key} = {value}")
+            
+            # Display helpful messages for provider configuration
+            if key == "provider":
+                provider_info = cfg.PROVIDER_DEFAULTS.get(value, {})
+                if provider_info.get("base_url"):
+                    console.print(f"[dim]Default base URL: {provider_info['base_url']}[/dim]")
+                if not provider_info.get("requires_api_key", True):
+                    console.print("[dim]API key not required for this provider[/dim]")
+                else:
+                    console.print("[yellow]⚠[/yellow]  Don't forget to set your API key: aigit config set openai_api_key <key>")
+                    
+            if key == "base_url" and value:
+                console.print("[dim]Custom base URL will override provider default[/dim]")
+                
         except Exception as e:
             console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(1)

--- a/aigit/config.py
+++ b/aigit/config.py
@@ -98,16 +98,16 @@ def set_config(key: str, value: Any) -> None:
 def get_openai_api_key() -> str:
     """Get OpenAI API key from config or environment."""
     provider = get_config("provider") or "openai"
-    
+
     # Check if provider requires API key
     provider_info = PROVIDER_DEFAULTS.get(provider, PROVIDER_DEFAULTS["custom"])
-    
+
     key = os.environ.get("OPENAI_API_KEY") or get_config("openai_api_key")
-    
+
     # If provider doesn't require API key, return a dummy key
     if not provider_info["requires_api_key"]:
         return key or "not-needed"
-    
+
     if not key:
         raise ValueError(
             "OpenAI API key not found. Set it with:\n"
@@ -121,23 +121,23 @@ def get_provider_config() -> dict[str, Any]:
     """Get provider configuration including base_url and api_key."""
     provider = get_config("provider") or "openai"
     custom_base_url = get_config("base_url")
-    
+
     # Get provider defaults
     provider_info = PROVIDER_DEFAULTS.get(provider, PROVIDER_DEFAULTS["custom"])
-    
+
     # Custom base_url overrides provider default
     base_url = custom_base_url if custom_base_url else provider_info["base_url"]
-    
+
     # Get API key
     api_key = get_openai_api_key()
-    
+
     config = {
         "provider": provider,
         "api_key": api_key,
         "base_url": base_url,
         "requires_api_key": provider_info["requires_api_key"],
     }
-    
+
     return config
 
 

--- a/aigit/config.py
+++ b/aigit/config.py
@@ -10,6 +10,34 @@ import tomli_w
 CONFIG_DIR = Path.home() / ".config" / "aigit"
 CONFIG_FILE = CONFIG_DIR / "config.toml"
 
+# Supported providers and their default base URLs
+PROVIDER_DEFAULTS = {
+    "openai": {
+        "base_url": None,  # Use OpenAI SDK default
+        "requires_api_key": True,
+    },
+    "ollama": {
+        "base_url": "http://localhost:11434/v1",
+        "requires_api_key": False,
+    },
+    "llamacpp": {
+        "base_url": "http://localhost:8080/v1",
+        "requires_api_key": False,
+    },
+    "vllm": {
+        "base_url": "http://localhost:8000/v1",
+        "requires_api_key": False,
+    },
+    "openrouter": {
+        "base_url": "https://openrouter.ai/api/v1",
+        "requires_api_key": True,
+    },
+    "custom": {
+        "base_url": None,  # User must specify
+        "requires_api_key": True,  # Safer default
+    },
+}
+
 DEFAULT_CONFIG = {
     "openai_api_key": "",
     "github_token": "",
@@ -17,6 +45,8 @@ DEFAULT_CONFIG = {
     "conventional_commits": True,
     "auto_stage": False,
     "interactive": True,
+    "provider": "openai",
+    "base_url": "",
 }
 
 
@@ -67,7 +97,17 @@ def set_config(key: str, value: Any) -> None:
 
 def get_openai_api_key() -> str:
     """Get OpenAI API key from config or environment."""
+    provider = get_config("provider") or "openai"
+    
+    # Check if provider requires API key
+    provider_info = PROVIDER_DEFAULTS.get(provider, PROVIDER_DEFAULTS["custom"])
+    
     key = os.environ.get("OPENAI_API_KEY") or get_config("openai_api_key")
+    
+    # If provider doesn't require API key, return a dummy key
+    if not provider_info["requires_api_key"]:
+        return key or "not-needed"
+    
     if not key:
         raise ValueError(
             "OpenAI API key not found. Set it with:\n"
@@ -75,6 +115,30 @@ def get_openai_api_key() -> str:
             "Or set the OPENAI_API_KEY environment variable."
         )
     return key
+
+
+def get_provider_config() -> dict[str, Any]:
+    """Get provider configuration including base_url and api_key."""
+    provider = get_config("provider") or "openai"
+    custom_base_url = get_config("base_url")
+    
+    # Get provider defaults
+    provider_info = PROVIDER_DEFAULTS.get(provider, PROVIDER_DEFAULTS["custom"])
+    
+    # Custom base_url overrides provider default
+    base_url = custom_base_url if custom_base_url else provider_info["base_url"]
+    
+    # Get API key
+    api_key = get_openai_api_key()
+    
+    config = {
+        "provider": provider,
+        "api_key": api_key,
+        "base_url": base_url,
+        "requires_api_key": provider_info["requires_api_key"],
+    }
+    
+    return config
 
 
 def get_github_token() -> str:

--- a/aigit/services/ai.py
+++ b/aigit/services/ai.py
@@ -2,12 +2,20 @@
 
 from openai import OpenAI
 
-from aigit.config import get_openai_api_key, get_config
+from aigit.config import get_provider_config, get_config
 
 
 def get_client() -> OpenAI:
     """Get OpenAI client."""
-    return OpenAI(api_key=get_openai_api_key())
+    provider_config = get_provider_config()
+    
+    # Initialize client with base_url if provided
+    client_args = {"api_key": provider_config["api_key"]}
+    
+    if provider_config["base_url"]:
+        client_args["base_url"] = provider_config["base_url"]
+    
+    return OpenAI(**client_args)
 
 
 def generate(prompt: str, max_tokens: int = 1024) -> str:

--- a/aigit/services/ai.py
+++ b/aigit/services/ai.py
@@ -8,13 +8,13 @@ from aigit.config import get_provider_config, get_config
 def get_client() -> OpenAI:
     """Get OpenAI client."""
     provider_config = get_provider_config()
-    
+
     # Initialize client with base_url if provided
     client_args = {"api_key": provider_config["api_key"]}
-    
+
     if provider_config["base_url"]:
         client_args["base_url"] = provider_config["base_url"]
-    
+
     return OpenAI(**client_args)
 
 


### PR DESCRIPTION
Adds support for multiple AI providers including Ollama, Llama.cpp, vLLM, OpenRouter, and custom endpoints.

## Features
- Provider-based configuration with sensible defaults
- Optional API key for local providers (Ollama, Llama.cpp, vLLM)
- Support for custom endpoints via base_url parameter
- Comprehensive documentation with setup examples for each provider

## Changes
- Updated `aigit/config.py` with provider config and defaults
- Modified `aigit/services/ai.py` to support base_url
- Added provider validation in `aigit/commands/config.py`
- Updated README.md and QUICKSTART.md with provider examples

## Usage Examples
```bash
# Ollama (no API key needed!)
aigit config set provider ollama
aigit config set model llama3.2

# OpenRouter
aigit config set provider openrouter
aigit config set openai_api_key sk-or-v1-...
aigit config set model anthropic/claude-3.5-sonnet
```

Closes #1